### PR TITLE
Add election schedule and inaugural committee

### DIFF
--- a/elections/election-2021.md
+++ b/elections/election-2021.md
@@ -1,0 +1,17 @@
+# Election of BSC Representatives 2021-08
+
+In accordance with the [eBPF Foundation Charter][charter], the following
+representatives were nominated to sit on the inaugural eBPF Steering Committee:
+
+| Name               | Affiliation     | Role                     | Section 4.b                       |
+| ------------------ | --------------- | ------------------------ | --------------------------------- |
+| Alexei Starovoitov | Facebook (Meta) | Linux eBPF Maintainer    | Kernel Representative             |
+| Daniel Borkmann    | Isovalent       | Linux eBPF Maintainer    | Kernel Representative             |
+| Dave Thaler        | Microsoft       | eBPF Runtime for Windows | eBPF Runtime Representative       |
+| Lorenz Bauer       | CloudFlare      | eBPF Go library          | Additional Project Representative |
+| KP Singh           | Google          | eBPF LSM                 | Additional Project Representative |
+| Andrii Nakryiko    | Facebook (Meta) | Katran                   | Maintainer Representative         |
+| Brendan Gregg      | Netflix         | BCC/bpftrace             | Maintainer Representative         |
+| Joe Stringer       | Isovalent       | Cilium                   | Maintainer Representative         |
+
+[charter]: https://ebpf.io/charter/

--- a/elections/schedule.md
+++ b/elections/schedule.md
@@ -1,0 +1,42 @@
+# eBPF Steering Committee elections schedule
+
+This process is derived from the [eBPF Foundation Charter][charter].
+
+Each year, the BSC prepares to nominate a portion of its members according to
+the following schedule:
+
+| Milestone    | Target Date  |
+| -------------| ------------ |
+| Nominations  | August       |
+| Election     | September    |
+| New BSC sits | October      |
+
+## Nominations
+
+The Charter §4.b describes the composition of the voting members of the BSC
+based around the projects that they are actively involved in. Broadly speaking,
+these are comprised of active contributors to specific projects nominated by
+the BSC under categories defined by the Charter. The BSC coordinates with
+individual eBPF projects in order to nominate individuals to represent the eBPF
+community in the BSC.
+
+The nomination process is intended to identify projects and individuals whose
+input will further the goals of the BSC as outlined in the Charter §4.b. Part
+of this process involves selecting projects from which to draw individuals, and
+part of this process involves nominating individuals from those projects. There
+is no strict order between these two portions of the nomination phase.
+
+## Election
+
+The outcome of the nominations is a set of people who represent categories of
+voting members in the Charter §4.b. The chair will call for an election during
+September to select members to join the BSC in the following term, conducting
+voting as per the Charter §5, typically during a regularly scheduled BSC
+meeting.
+
+## New BSC sits
+
+Following the election of new members for the BSC, this repository should be
+updated to reflect the results of the election and the new membership.
+
+[charter]: https://ebpf.io/charter/


### PR DESCRIPTION
Add an outline for the intended schedule for BSC member elections and the
process implemented based upon the eBPF Foundation Charter.