### PR TITLE
Nominate projects for 2022-2024 BSC terms

### DIFF
--- a/elections/election-2022.md
+++ b/elections/election-2022.md
@@ -1,0 +1,115 @@
+# Project nomination for BSC representatives 2022
+
+In accordance with the [Elections Schedule](./schedule.md) and the
+[eBPF Foundation Charter][charter], this page holds a public record of the
+steps undertaken to nominate members for the BSC in 2022.
+
+The following members' terms will expire in 2022. The Section 4.b column
+indicates which projects must be considered to draw nominations from.
+
+| Name    | Section 4.b  |
+| ------- | ------------ |
+| (empty) | eBPF runtime |
+| TBD     |              |
+
+## Nominations (ETA August)
+
+The following nominees are under consideration for election to the BSC.
+
+### Kernel Candidates
+
+_[eBPF Foundation Charter][charter] §4.b.i Two Linux Kernel representatives
+from the group of eBPF Linux kernel maintainers (as specified in the Linux eBPF
+maintainer file). The Linux Kernel representatives must not be employed by the
+same Company or by Related Companies._
+
+* TBD
+
+### Runtime Candidates
+
+_[eBPF Foundation Charter][charter] §4.b.ii Up to two representatives from
+other open source eBPF runtime implementations.￼Each “eBPF Runtime
+Representative” will represent a different eBPF runtime chosen by the BSC, and
+must be an active contributor to that eBPF runtime._
+
+* eBPF Runtime for Windows
+* hBPF
+
+### Technical Project Candidates
+
+_[eBPF Foundation Charter][charter] §4.b.iii Up to three technical project
+representatives. Each Technical Project Representative candidate must be an
+active contributor to a different Technical Project chosen by the BSC._
+
+* TBD
+
+### Additional Project Candidates
+
+_[eBPF Foundation Charter][charter] §4.b.iv Up to two eBPF Landscape Project
+representatives. Each eBPF Landscape Project Representative candidate must be
+an active contributor to a different eBPF Landscape Project chosen by the
+BSC.._
+
+#### Major Applications
+* BCC[^1]
+* Cilium
+* bpftrace[^1]
+* Falco
+* Katran
+* Pixie
+
+#### Emerging Applications
+
+* Pyroscope
+* eCapture
+* Procmon for Linux[^2]
+* Parca[^2]
+* Hubble
+* Tracee
+* Tetragon
+* kubectl trace[^1]
+* BumbleBee
+* pwru
+* ply[^1]
+* KubeArmor
+* Merbridge
+* L3AF
+* LoxiLB
+
+#### eBPF Libraries
+
+* eBPF Go library
+* libbpfgo
+* libbpf
+* libxdp
+* libbpf-rs
+* Redbpf
+* Aya (Rust library)
+
+[^1]: Tentatively an option for technical project, in which case we would
+      remove it from this category.
+[^2]: Not currently listed in the landscape project, but expected soon.
+
+## Election (ETA September)
+
+The following representatives were nominated to sit on the eBPF Steering Committee:
+
+* TBD
+
+## New BSC sits (ETA October)
+
+The full set of members in the BSC are:
+
+| Name               | Affiliation     | Role                     | Section (4)(b)                    | Term Ends |
+| ------------------ | --------------- | ------------------------ | --------------------------------- | --------- |
+|                    |                 |                          |                                   |           |
+|                    |                 |                          |                                   |           |
+|                    |                 |                          |                                   |           |
+|                    |                 |                          |                                   |           |
+|                    |                 |                          |                                   |           |
+|                    |                 |                          |                                   |           |
+|                    |                 |                          |                                   |           |
+|                    |                 |                          |                                   |           |
+
+[charter]: https://ebpf.io/charter/
+


### PR DESCRIPTION
This PR follows the process in #5 to initiate a discussion in the BSC for
member nomination for the 2022-2024 term.
