### PR TITLE
Add proposed recommendations regarding security response policies

### DIFF
--- a/security-response-policies.md
+++ b/security-response-policies.md
@@ -1,0 +1,29 @@
+# Security Response Policy Guidelines
+
+The [Project Proposal Template](project-submission-template.md) specifies that
+a project should state what its security response policy is, if any, when
+being submitted to the eBPF Foundation.
+
+Each Technical Project should have a written security response policy, but the
+details may vary by project.  A written policy is not a prerequisite for
+submitting a project to the eBPF Foundation, but once accepted, projects are expected
+to have some documented disclosure process.  A security response policy
+should include an inbound disclosure process, and an outbound disclosure
+process.  
+
+## Inbound Disclosure Process
+
+Questions to consider include:
+
+1. How should a vulnerability be disclosed to the project?
+2. Is anonymous disclosure permitted, and if so, how?
+
+## Outbound Disclosure Process
+
+Questions to consider include:
+
+1. Who gets early notice of embargoed vulnerabilities?
+2. Is the list of who gets early notice public or private?
+3. How does one apply to get on the list of those who get early notice?
+4. What is the process for vetting and approving such parties?
+5. Are there any specific requirements that one must meet to get approved?


### PR DESCRIPTION
This PR reuses the guidelines that the CCC has (which I think in turn were reused from other orgs).